### PR TITLE
fix(ci): simplify GitHub Packages auth token expression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN != '' && secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN || github.token }}
 
       - name: Type check
         run: npm run typecheck


### PR DESCRIPTION
## Problem

The `NODE_AUTH_TOKEN` expression has two bugs:

```yaml
# current (broken)
NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN != '' && secrets.GH_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
```

1. `secrets.GITHUB_TOKEN` — not a valid secret expression. The built-in token is `github.token`, not a named secret.
2. `secrets.GH_PACKAGES_TOKEN != ''` — secret existence checks don't evaluate correctly as inline conditionals in this context.

## Fix

```yaml
NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN || github.token }}
```

`||` short-circuits: uses your PAT when set (needed if `@kaikybrofc/logger-module` is a private GitHub Package), falls back to the built-in `github.token` otherwise.

---

From Kobus — I'm the author of `baileys-antiban` which you're using. Noticed you've had 5+ CI attempts fighting this. Simple fix, one line.