### PR TITLE
feat: upgrade to Baileys rc11 + switch to npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
     "@caed0/webp-conv": "^2.2.3",
     "@hapi/boom": "^10.0.1",
     "@kaikybrofc/logger-module": "^1.0.4",
-    "@whiskeysockets/baileys": "github:WhiskeySockets/Baileys#v7.0.0-rc10",
-    "baileys-antiban": "github:kobie3717/baileys-antiban#master",
+    "baileys": "npm:@whiskeysockets/baileys@7.0.0-rc11",
+    "baileys-antiban": "^1.0.0",
+    "libsignal": "2.0.1",
     "dotenv": "^16.4.5",
     "fflate": "^0.8.2",
     "link-preview-js": "4.0.1",
@@ -59,11 +60,8 @@
   "overrides": {
     "vite": "8.0.5",
     "basic-ftp": "5.3.1",
-    "libsignal": {
-      "protobufjs": "7.5.8"
-    },
-    "@whiskeysockets/libsignal-node": {
-      "protobufjs": "7.5.8"
+    "baileys": {
+      "libsignal": "$libsignal"
     },
     "link-preview-js": "4.0.1"
   }

--- a/src/bootstrap/start.ts
+++ b/src/bootstrap/start.ts
@@ -1,4 +1,4 @@
-import type { WASocket } from '@whiskeysockets/baileys'
+import type { WASocket } from 'baileys'
 import { createLogger, type AppLogger } from '../observability/logger.js'
 import { createSocket, isShutdownInProgress, unregisterShutdownTarget } from '../core/connection/socket.js'
 import { registerEvents } from '../events/register.js'

--- a/src/core/auth/creds-utils.ts
+++ b/src/core/auth/creds-utils.ts
@@ -1,4 +1,4 @@
-import { initAuthCreds, type AuthenticationCreds } from '@whiskeysockets/baileys'
+import { initAuthCreds, type AuthenticationCreds } from 'baileys'
 
 /**
  * Representa a origem de onde as credenciais foram recuperadas.

--- a/src/core/auth/mysql-auth-state.ts
+++ b/src/core/auth/mysql-auth-state.ts
@@ -1,4 +1,4 @@
-import { type AuthenticationCreds, type AuthenticationState, type SignalDataSet, type SignalDataTypeMap, type SignalKeyStore } from '@whiskeysockets/baileys'
+import { type AuthenticationCreds, type AuthenticationState, type SignalDataSet, type SignalDataTypeMap, type SignalKeyStore } from 'baileys'
 import type { RowDataPacket } from 'mysql2/promise'
 import { config } from '../../config/index.js'
 import { ensureMysqlConnection } from '../db/connection.js'

--- a/src/core/auth/redis-auth-state.ts
+++ b/src/core/auth/redis-auth-state.ts
@@ -1,4 +1,4 @@
-import { type AuthenticationCreds, type AuthenticationState, type SignalDataSet, type SignalDataTypeMap, type SignalKeyStore } from '@whiskeysockets/baileys'
+import { type AuthenticationCreds, type AuthenticationState, type SignalDataSet, type SignalDataTypeMap, type SignalKeyStore } from 'baileys'
 import { config } from '../../config/index.js'
 import { getRedisClient } from '../redis/client.js'
 import { getLegacyRedisNamespace, getRedisNamespace } from '../redis/prefix.js'

--- a/src/core/auth/state.ts
+++ b/src/core/auth/state.ts
@@ -1,4 +1,4 @@
-import { useMultiFileAuthState, type AuthenticationState } from '@whiskeysockets/baileys'
+import { useMultiFileAuthState, type AuthenticationState } from 'baileys'
 import { config } from '../../config/index.js'
 import { resolveAuthDir } from './auth-dir.js'
 import { useMysqlAuthState } from './mysql-auth-state.js'

--- a/src/core/auth/storage-utils.ts
+++ b/src/core/auth/storage-utils.ts
@@ -1,4 +1,4 @@
-import { BufferJSON, proto, type SignalDataTypeMap } from '@whiskeysockets/baileys'
+import { BufferJSON, proto, type SignalDataTypeMap } from 'baileys'
 import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 

--- a/src/core/command-runtime/admin.ts
+++ b/src/core/command-runtime/admin.ts
@@ -1,4 +1,4 @@
-import { jidNormalizedUser, type GroupMetadata, type ParticipantAction, type WASocket } from '@whiskeysockets/baileys'
+import { jidNormalizedUser, type GroupMetadata, type ParticipantAction, type WASocket } from 'baileys'
 
 /**
  * Alvo de um participante, pode ser um único JID ou uma lista de JIDs.

--- a/src/core/command-runtime/context.ts
+++ b/src/core/command-runtime/context.ts
@@ -2,7 +2,7 @@ import type {
   AnyMessageContent,
   MiscMessageGenerationOptions,
   WAMessage,
-} from '@whiskeysockets/baileys'
+} from 'baileys'
 import type { StickerSourceMedia } from '../../utils/sticker.js'
 import type {
   CommandAdminActions,

--- a/src/core/command-runtime/processor.ts
+++ b/src/core/command-runtime/processor.ts
@@ -1,4 +1,4 @@
-import { type WAMessage, type WASocket, type proto } from '@whiskeysockets/baileys'
+import { type WAMessage, type WASocket, type proto } from 'baileys'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import linkify from 'linkifyjs'

--- a/src/core/connection/history-sync.ts
+++ b/src/core/connection/history-sync.ts
@@ -1,4 +1,4 @@
-import type { proto, AuthenticationCreds } from '@whiskeysockets/baileys'
+import type { proto, AuthenticationCreds } from 'baileys'
 
 export type HistorySyncPolicy = {
   allowOnceForNewLogin: () => void

--- a/src/core/connection/socket.ts
+++ b/src/core/connection/socket.ts
@@ -1,4 +1,4 @@
-import makeWASocket, { Browsers, DEFAULT_CONNECTION_CONFIG, DisconnectReason, fetchLatestBaileysVersion, useMultiFileAuthState, type SignalRepositoryWithLIDStore } from '@whiskeysockets/baileys'
+import makeWASocket, { Browsers, DEFAULT_CONNECTION_CONFIG, DisconnectReason, fetchLatestBaileysVersion, useMultiFileAuthState, type SignalRepositoryWithLIDStore } from 'baileys'
 import type { WarmUpState } from 'baileys-antiban'
 import { Boom } from '@hapi/boom'
 import { config } from '../../config/index.js'

--- a/src/core/db/backfill.ts
+++ b/src/core/db/backfill.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { stat } from 'node:fs/promises'
 import path from 'node:path'
-import { type AuthenticationCreds, BufferJSON, type GroupMetadata, type WAMessage } from '@whiskeysockets/baileys'
+import { type AuthenticationCreds, BufferJSON, type GroupMetadata, type WAMessage } from 'baileys'
 import type { ResultSetHeader, RowDataPacket } from 'mysql2/promise'
 import { loadEnv } from '../../bootstrap/env.js'
 import { config } from '../../config/index.js'

--- a/src/events/register.ts
+++ b/src/events/register.ts
@@ -1,4 +1,4 @@
-import { DisconnectReason, jidDecode, type BaileysEventMap, type GroupMetadata, type WAMessage, type WASocket } from '@whiskeysockets/baileys'
+import { DisconnectReason, jidDecode, type BaileysEventMap, type GroupMetadata, type WAMessage, type WASocket } from 'baileys'
 import { Boom } from '@hapi/boom'
 import qrcode from 'qrcode-terminal'
 import type { AppLogger } from '../observability/logger.js'

--- a/src/observability/baileys-logger.ts
+++ b/src/observability/baileys-logger.ts
@@ -1,4 +1,4 @@
-import type { ILogger } from '@whiskeysockets/baileys/lib/Utils/logger.js'
+import type { ILogger } from 'baileys/lib/Utils/logger.js'
 import type { AppLogger } from './logger.js'
 
 type Meta = Record<string, unknown>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,4 @@
-import { type WASocket, type proto } from '@whiskeysockets/baileys'
+import { type WASocket, type proto } from 'baileys'
 import type { AppLogger } from '../observability/logger.js'
 import type { SqlStore } from '../store/sql-store.js'
 import { createCommandProcessor } from '../core/command-runtime/processor.js'

--- a/src/store/baileys-store.ts
+++ b/src/store/baileys-store.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CACHE_TTLS, type BaileysEventEmitter, type CacheStore, type Chat, type ChatUpdate, type Contact, type GroupMetadata, type GroupParticipant, type LIDMapping, type PossiblyExtendedCacheStore, type WAMessage, type WAMessageKey } from '@whiskeysockets/baileys'
+import { DEFAULT_CACHE_TTLS, type BaileysEventEmitter, type CacheStore, type Chat, type ChatUpdate, type Contact, type GroupMetadata, type GroupParticipant, type LIDMapping, type PossiblyExtendedCacheStore, type WAMessage, type WAMessageKey } from 'baileys'
 import { createCacheStore, createExtendedCacheStore } from './cache-store.js'
 import { createRedisStore } from './redis-store.js'
 import { createSqlStore } from './sql-store.js'

--- a/src/store/cache-store.ts
+++ b/src/store/cache-store.ts
@@ -1,4 +1,4 @@
-import { BufferJSON, type CacheStore, type PossiblyExtendedCacheStore } from '@whiskeysockets/baileys'
+import { BufferJSON, type CacheStore, type PossiblyExtendedCacheStore } from 'baileys'
 import { config } from '../config/index.js'
 import { getRedisClient } from '../core/redis/client.js'
 

--- a/src/store/redis-store.ts
+++ b/src/store/redis-store.ts
@@ -1,4 +1,4 @@
-import { BufferJSON, type Chat, type Contact, type GroupMetadata, type LIDMapping, type WAMessage } from '@whiskeysockets/baileys'
+import { BufferJSON, type Chat, type Contact, type GroupMetadata, type LIDMapping, type WAMessage } from 'baileys'
 import { config } from '../config/index.js'
 import { getRedisClient } from '../core/redis/client.js'
 import { getRedisNamespace } from '../core/redis/prefix.js'

--- a/src/store/sql-store.ts
+++ b/src/store/sql-store.ts
@@ -1,4 +1,4 @@
-import { BufferJSON, type Chat, type Contact, type GroupMetadata, type GroupParticipant, type LIDMapping, type WAMessage, type proto } from '@whiskeysockets/baileys'
+import { BufferJSON, type Chat, type Contact, type GroupMetadata, type GroupParticipant, type LIDMapping, type WAMessage, type proto } from 'baileys'
 import type { RowDataPacket } from 'mysql2/promise'
 import { randomUUID } from 'node:crypto'
 import { config } from '../config/index.js'

--- a/src/utils/media-download.ts
+++ b/src/utils/media-download.ts
@@ -1,4 +1,4 @@
-import { downloadContentFromMessage } from '@whiskeysockets/baileys'
+import { downloadContentFromMessage } from 'baileys'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { config } from '../config/index.js'

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,4 +1,4 @@
-import { extractMessageContent, getContentType, normalizeMessageContent, proto } from '@whiskeysockets/baileys'
+import { extractMessageContent, getContentType, normalizeMessageContent, proto } from 'baileys'
 
 type NormalizedMessage = {
   content: proto.IMessage | undefined

--- a/src/utils/sticker.ts
+++ b/src/utils/sticker.ts
@@ -1,4 +1,4 @@
-import { downloadContentFromMessage, extractMessageContent, getContentType, normalizeMessageContent, type proto } from '@whiskeysockets/baileys'
+import { downloadContentFromMessage, extractMessageContent, getContentType, normalizeMessageContent, type proto } from 'baileys'
 import { randomUUID } from 'node:crypto'
 import { spawn } from 'node:child_process'
 import fs from 'node:fs/promises'

--- a/tests/auth-state.test.ts
+++ b/tests/auth-state.test.ts
@@ -31,8 +31,8 @@ const useMultiFileAuthState = vi.fn(async (_authDir: string) => ({
   state: { creds: { from: 'disk' } } as never,
   saveCreds: vi.fn(async () => undefined),
 }))
-vi.mock('@whiskeysockets/baileys', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@whiskeysockets/baileys')>()
+vi.mock('baileys', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('baileys')>()
   return { ...actual, useMultiFileAuthState }
 })
 

--- a/tests/creds-utils.test.ts
+++ b/tests/creds-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { initAuthCreds, type AuthenticationCreds } from '@whiskeysockets/baileys'
+import { initAuthCreds, type AuthenticationCreds } from 'baileys'
 import { normalizeCreds, scoreCreds, selectBestCreds } from '../src/core/auth/creds-utils.js'
 
 describe('creds-utils', () => {

--- a/tests/history-sync.test.ts
+++ b/tests/history-sync.test.ts
@@ -1,4 +1,4 @@
-import { initAuthCreds } from '@whiskeysockets/baileys'
+import { initAuthCreds } from 'baileys'
 import { describe, expect, it } from 'vitest'
 
 describe('history-sync', () => {

--- a/tests/media-download.test.ts
+++ b/tests/media-download.test.ts
@@ -10,7 +10,7 @@ const mockConfig = {
   mediaDownloadDir: 'data/media',
 }
 
-vi.mock('@whiskeysockets/baileys', () => ({
+vi.mock('baileys', () => ({
   downloadContentFromMessage: (...args: unknown[]) => downloadContentFromMessageMock(...args),
 }))
 

--- a/tests/mysql-auth-state.test.ts
+++ b/tests/mysql-auth-state.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { BufferJSON, initAuthCreds, type AuthenticationCreds } from '@whiskeysockets/baileys'
+import { BufferJSON, initAuthCreds, type AuthenticationCreds } from 'baileys'
 import { join } from 'node:path'
 
 const serialize = (value: unknown) => JSON.stringify(value, BufferJSON.replacer)

--- a/tests/redis-auth-state.test.ts
+++ b/tests/redis-auth-state.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { BufferJSON, initAuthCreds, type AuthenticationCreds } from '@whiskeysockets/baileys'
+import { BufferJSON, initAuthCreds, type AuthenticationCreds } from 'baileys'
 import { join } from 'node:path'
 
 const serialize = (value: unknown) => JSON.stringify(value, BufferJSON.replacer)

--- a/tests/socket.test.ts
+++ b/tests/socket.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { DisconnectReason, initAuthCreds, type AuthenticationState } from '@whiskeysockets/baileys'
+import { DisconnectReason, initAuthCreds, type AuthenticationState } from 'baileys'
 
 let makeWASocketMock: ReturnType<typeof vi.fn>
 let fetchLatestMock: ReturnType<typeof vi.fn>
@@ -22,8 +22,8 @@ const mockConfig = {
   antibanStateSaveIntervalMs: 300000,
 }
 
-vi.mock('@whiskeysockets/baileys', async () => {
-  const actual = await vi.importActual<typeof import('@whiskeysockets/baileys')>('@whiskeysockets/baileys')
+vi.mock('baileys', async () => {
+  const actual = await vi.importActual<typeof import('baileys')>('baileys')
   return {
     ...actual,
     default: (...args: unknown[]) => makeWASocketMock(...args),


### PR DESCRIPTION
## Changes

### Baileys rc10 → rc11
- `@whiskeysockets/baileys` github source → `npm:@whiskeysockets/baileys@7.0.0-rc11`
- Aliased as `baileys` (canonical npm name)
- All 29 source + test files updated: `@whiskeysockets/baileys` → `baileys`

### baileys-antiban: github → npm
- `github:kobie3717/baileys-antiban#master` → `^1.0.0` (published npm package)
- Faster installs, proper semver, no git dependency at install time

### libsignal pin
- Added `"libsignal": "2.0.1"` as direct dep + override `baileys → libsignal: "$libsignal"`
- Replaces the protobufjs hackfix overrides — cleaner and battle-tested (running in WhatsAuction prod)

## Why rc11?
rc11 is the latest stable release candidate. Running in production on WhatsAuction as of 2026-05-15 with no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)