### PR TITLE
[codex] fix api webhook port conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,10 +326,10 @@ npm run pm2:logs
 O `ecosystem.config.cjs` inicia:
 
 - `zyra`: processo de conexões/sockets, com API habilitada em `127.0.0.1:3021` por padrão do PM2
-- `zyra-api-webhook`: control-plane HTTP, dashboard e workers de webhook, sem gerenciar sockets locais; usa `WA_API_PORT` do `.env` ou `3000` quando não definido
+- `zyra-api-webhook`: control-plane HTTP, dashboard e workers de webhook, sem gerenciar sockets locais; usa `127.0.0.1:3020` por padrão do PM2
 - `zyra-backfill`: worker contínuo de backfill do banco
 
-Como o `.env` é carregado no boot, valores que não estiverem sobrescritos no `ecosystem.config.cjs` continuam vindo do `.env`. Mantenha o `WA_API_PORT` do `.env` diferente de `3021` se for usar o processo `zyra-api-webhook` junto com o processo `zyra`.
+Como o `.env` é carregado no boot, valores que não estiverem sobrescritos no `ecosystem.config.cjs` continuam vindo do `.env`. No PM2, as portas da API são sobrescritas para evitar conflito com serviços que já usam `3000`.
 
 Após validar a subida:
 
@@ -735,7 +735,7 @@ Notas operacionais:
 
 - o processo `zyra` pode manter múltiplas sessões ativas ao mesmo tempo
 - o processo `zyra-api-webhook` roda com `WA_BOOTSTRAP_CONNECTIONS_ENABLED=false` e atua como control-plane HTTP
-- no PM2, `zyra` força `WA_API_PORT=3021`; deixe o `WA_API_PORT` do `.env` em outra porta para o `zyra-api-webhook`, como `3000`
+- no PM2, `zyra` força `WA_API_PORT=3021` e `zyra-api-webhook` força `WA_API_PORT=3020`
 - prefira `WA_CONNECTION_IDS` quando quiser controle explícito do conjunto de sessões
 - prefira descoberta via MySQL quando `auth_creds` já for a fonte de verdade das sessões persistidas
 - para parear uma nova conta via QR no terminal, use `npm run session:pair -- --connection <id>`

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -53,6 +53,8 @@ module.exports = {
       env_production: {
         NODE_ENV: 'production',
         WA_API_ENABLED: 'true',
+        WA_API_HOST: '127.0.0.1',
+        WA_API_PORT: '3020',
         WA_BOOTSTRAP_CONNECTIONS_ENABLED: 'false',
         WA_WEBHOOK_RETRY_ENABLED: 'true',
         WA_WEBHOOK_OUTBOX_ENABLED: 'true',

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server } from 'node:http'
+import process from 'node:process'
 import { config } from '../config/index.js'
 import type { AppLogger } from '../observability/logger.js'
 import { parseUrl, sendError } from './http.js'
@@ -122,10 +123,22 @@ export const startApiServer = ({ logger }: StartApiServerOptions): ApiServerHand
     }
   })
 
-  server.listen(config.apiPort, config.apiHost, () => {
+  const host = config.apiHost
+  const port = config.apiPort
+
+  server.on('error', (error) => {
+    logger.error('falha ao iniciar servidor HTTP da API REST', {
+      err: error,
+      host,
+      port,
+    })
+    process.exit(1)
+  })
+
+  server.listen(port, host, () => {
     logger.info('servidor HTTP da API REST iniciado', {
-      host: config.apiHost,
-      port: config.apiPort,
+      host,
+      port,
     })
   })
 

--- a/tests/api-server.test.ts
+++ b/tests/api-server.test.ts
@@ -27,6 +27,7 @@ const mockConfig = {
 let serverHandler: RequestHandler | null = null
 const serverListenMock = vi.fn((_port: number, _host: string, cb?: () => void) => cb?.())
 const serverCloseMock = vi.fn((cb?: (error?: Error | null) => void) => cb?.(null))
+const serverOnMock = vi.fn()
 
 const handleConnectionsRoutesMock = vi.fn(async () => false)
 const handleMessagesRoutesMock = vi.fn(async () => false)
@@ -41,6 +42,7 @@ vi.mock('node:http', () => ({
   createServer: (handler: RequestHandler) => {
     serverHandler = handler
     return {
+      on: (...args: Parameters<typeof serverOnMock>) => serverOnMock(...args),
       listen: (...args: Parameters<typeof serverListenMock>) => serverListenMock(...args),
       close: (...args: Parameters<typeof serverCloseMock>) => serverCloseMock(...args),
     }


### PR DESCRIPTION
## Summary

- Pin `zyra-api-webhook` to `127.0.0.1:3020` in the PM2 ecosystem config so it no longer inherits or defaults to port `3000`.
- Log API server bind failures with the resolved host and port before exiting, making future `EADDRINUSE` failures easier to diagnose.
- Update PM2 documentation to describe the fixed API ports.

## Root Cause

`zyra-api-webhook` did not override `WA_API_HOST` or `WA_API_PORT`, so it could inherit `WA_API_PORT=3000` from `.env` or fall back to the default `3000`. On the target host, `0.0.0.0:3000` was already in use, causing `listen EADDRINUSE` and PM2 restarts.

## Validation

- `npm run build`
- `npx vitest run tests/api-server.test.ts`
- Runtime check: `zyra-api-webhook` started online under PM2 and listened on `127.0.0.1:3020`; existing `3000` listener was no longer used by this process.
